### PR TITLE
Update colmap instructions and gcc version for OpenMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you are interested in potential collaboration or internship at ByteDance, ple
 ## Installation
 1. Install dependencies:
 * Ceres 2.0.0 [[Guide](./misc/doc/ceres.md)]
-* COLMAP [[Guide](https://colmap.github.io/install.html)]
+* COLMAP [[Guide](./misc/doc/colmap.md)]
 * Theia SfM (customized version) [[Guide](./misc/doc/theia.md)]
 
 2. Set up Python environment with Conda:

--- a/misc/doc/colmap.md
+++ b/misc/doc/colmap.md
@@ -23,6 +23,7 @@ sudo apt-get install \
     libqt5opengl5-dev \
     libcgal-dev \
     libceres-dev
+```
 
 Clone colmap, checkout the version which works with this repo, compile and install:
 ```

--- a/misc/doc/colmap.md
+++ b/misc/doc/colmap.md
@@ -1,0 +1,38 @@
+# Colmap installation
+
+First install packages to support Colmap:
+```
+sudo apt-get install \
+    git \
+    cmake \
+    ninja-build \
+    build-essential \
+    libboost-program-options-dev \
+    libboost-filesystem-dev \
+    libboost-graph-dev \
+    libboost-system-dev \
+    libeigen3-dev \
+    libflann-dev \
+    libfreeimage-dev \
+    libmetis-dev \
+    libgoogle-glog-dev \
+    libgtest-dev \
+    libsqlite3-dev \
+    libglew-dev \
+    qtbase5-dev \
+    libqt5opengl5-dev \
+    libcgal-dev \
+    libceres-dev
+
+Clone colmap, checkout the version which works with this repo, compile and install:
+```
+git clone https://github.com/colmap/colmap
+git checkout bd84ad6
+
+cd colmap
+mkdir build
+cd build
+cmake .. -GNinja
+ninja
+sudo ninja install
+```

--- a/sfm/gmapper/cmake/FindOpenMP.cmake
+++ b/sfm/gmapper/cmake/FindOpenMP.cmake
@@ -8,6 +8,9 @@ find_path(OpenMP_INCLUDE_DIR
     #HINTS /usr/lib/gcc/x86_64-linux-gnu/4.9/include/
     HINTS /usr/lib/gcc/x86_64-linux-gnu/8/include/
     HINTS /usr/lib/gcc/x86_64-linux-gnu/9/include/
+    HINTS /usr/lib/gcc/x86_64-linux-gnu/10/include/
+    HINTS /usr/lib/gcc/x86_64-linux-gnu/11/include/
+    HINTS /usr/lib/gcc/x86_64-linux-gnu/12/include/
 )
 
 mark_as_advanced(OpenMP_LIBRARY OpenMP_INCLUDE_DIR)


### PR DESCRIPTION
Latest changes to colmap repo break the compilation for this repo. I have updated the colmap installation instructions to checkout the version which works with this repo. I also added more gcc versions to check for OpenMP installation. 